### PR TITLE
G3-65: Geneweaver CLI Client Data Preview Tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-client"
-version = "0.4.0"
+version = "0.5.0a0"
 description = "A Python Client for the Geneweaver API"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 homepage = "https://thejacksonlaboratory.github.io/geneweaver-docs/"
 repository = "https://github.com/TheJacksonLaboratory/geneweaver-client"
 packages = [
-    { from="src", include= "geneweaver/client"}
+    { from = "src", include = "geneweaver/client" }
 ]
 
 [tool.poetry.scripts]

--- a/src/geneweaver/client/cli/alpha/parse/utils.py
+++ b/src/geneweaver/client/cli/alpha/parse/utils.py
@@ -1,10 +1,13 @@
 """CLI for parsing utility functions."""
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 import typer
 from geneweaver.client.parser import general
-from geneweaver.core.parse import xlsx
+from geneweaver.core.parse import csv, xlsx
 from geneweaver.core.parse.exceptions import EmptyFileError, UnsupportedFileTypeError
+from geneweaver.core.parse.utils import get_file_type
+from geneweaver.core.types import DictRow
 from rich import print
 from rich.console import Console
 from rich.table import Table
@@ -14,39 +17,23 @@ console = Console()
 
 
 @cli.command()
+def infer_file_format(file_path: Path) -> None:
+    """Infer the file format of a data file."""
+    file_type = get_file_type(file_path)
+    print(f"{file_type.name} - {file_type.value}")
+
+
+@cli.command()
 def get_headers(file_path: Path, sheet: str = None) -> None:
     """Get the headers from a data file."""
-    headers = []
     try:
-        headers = general.get_headers(file_path, sheet_name=sheet)
+        headers, _ = general.get_headers(file_path, sheet_name=sheet)
     except (EmptyFileError, ValueError, UnsupportedFileTypeError) as e:
         print(e)
         raise typer.Exit(code=1) from e
 
-    for header in headers:
-        print(header)
-
-
-@cli.command()
-def preview(file_path: Path, rows_to_read: int = 5, sheet: str = None) -> None:
-    """Preview the data in a data file."""
-    rows = []
-    try:
-        headers, headers_idx = general.get_headers(file_path, sheet_name=sheet)
-        rows = general.data_file_to_dict_n_rows(
-            file_path, rows_to_read, headers_idx, sheet_name=sheet
-        )
-    except ValueError as e:
-        print("File is empty.")
-        raise typer.Exit(code=1) from e
-    except (EmptyFileError, UnsupportedFileTypeError) as e:
-        print(e)
-        raise typer.Exit(code=1) from e
-
-    table = Table(*headers)
-    for row in rows:
-        table.add_row(*(str(r) for r in row.values()))
-    console.print(table)
+    for idx, header in enumerate(headers):
+        print(f"{idx} - {header}")
 
 
 @cli.command()
@@ -54,7 +41,154 @@ def get_sheet_names(file_path: Path) -> None:
     """Get the sheet names from an Excel file."""
     try:
         names = xlsx.get_sheet_names(file_path)
-        print(names)
     except ValueError as e:
         print(e)
         raise typer.Exit(code=1) from e
+
+    for idx, name in enumerate(names):
+        print(f"{idx} - {name}")
+
+
+@cli.command()
+def get_metadata(file_path: Path, sheet: Optional[str] = None) -> None:
+    """Get the metadata from a data file."""
+    file_type = get_file_type(file_path)
+
+    if file_type == "csv":
+        header, header_idx = csv.get_headers(file_path)
+        _print_metadata_csv(file_path, header_idx)
+    elif file_type == "xlsx":
+        sheet_names, sheet_metadata, _, _, n_sheets = _get_metadata_xlsx(
+            file_path, sheet
+        )
+        _print_metadata_xlsx(file_path, sheet_names, sheet_metadata, n_sheets)
+
+
+@cli.command()
+def preview(
+    file_path: Path, rows_to_read: int = 5, sheet: str = None, no_prompt: bool = False
+) -> None:
+    """Preview the data in a data file."""
+    file_type = get_file_type(file_path)
+
+    if file_type == "csv":
+        _preview_csv(file_path, rows_to_read, no_prompt)
+    elif file_type == "xlsx":
+        _preview_xlsx(file_path, rows_to_read, sheet, no_prompt)
+
+
+def _preview_csv(
+    file_path: Path, rows_to_read: int = 5, no_prompt: bool = False
+) -> None:
+    """Preview the data in a CSV file."""
+    header, header_idx = csv.get_headers(file_path)
+    _print_metadata_csv(file_path, header_idx)
+
+    if not no_prompt:
+        typer.confirm("Do you want to preview data?", default=True, abort=True)
+
+    rows = csv.read_to_dict_n_rows(file_path, rows_to_read, header_idx)
+    _print_format_data(header, rows)
+
+
+def _print_metadata_csv(file_path: Path, header_idx: int) -> None:
+    """Print the metadata from a CSV file."""
+    try:
+        metadata = general.read_metadata(file_path, header_idx)
+    except (EmptyFileError, ValueError, UnsupportedFileTypeError) as e:
+        print(e)
+        raise typer.Exit(code=1) from e
+
+    print(f"{file_path} contains:")
+    for metadata_line in metadata:
+        print(f" - {metadata_line}")
+
+
+def _get_metadata_xlsx(
+    file_path: Path, sheet: Optional[str] = None
+) -> Tuple[List[str], List[List[str]], List[List[str]], List[int], int]:
+    if sheet:
+        sheet_names = [sheet]
+        headers, headers_idx = xlsx.get_headers(file_path, sheet_name=sheet)
+        sheet_metadata = [
+            general.read_metadata(file_path, headers_idx, sheet_name=sheet)
+        ]
+        headers, headers_idx = [headers], [headers_idx]
+        n_sheets = 1
+    else:
+        sheet_names = xlsx.get_sheet_names(file_path)
+        headers, headers_idx = [], []
+        for s in sheet_names:
+            h, h_idx = xlsx.get_headers(file_path, sheet_name=s)
+            headers.append(h)
+            headers_idx.append(h_idx)
+
+        sheet_metadata = [
+            general.read_metadata(file_path, h, sheet_name=s)
+            for s, h in zip(sheet_names, headers_idx, strict=True)
+        ]
+        n_sheets = len(sheet_names)
+
+    return sheet_names, sheet_metadata, headers, headers_idx, n_sheets
+
+
+def _print_metadata_xlsx(
+    file_path: Path,
+    sheet_names: List[str],
+    sheet_metadata: List[List[str]],
+    n_sheets: int,
+) -> None:
+    print(f"{file_path} contains {n_sheets} sheets:")
+
+    for name, metadata in zip(sheet_names, sheet_metadata, strict=True):
+        print(f" - {name} - {metadata}")
+
+
+def _preview_xlsx(
+    file_path: Path, rows_to_read: int = 5, sheet: str = None, no_prompt: bool = False
+) -> None:
+    sheet_names, sheet_metadata, headers, headers_idx, n_sheets = _get_metadata_xlsx(
+        file_path, sheet
+    )
+
+    if not sheet:
+        _print_metadata_xlsx(file_path, sheet_names, sheet_metadata, n_sheets)
+
+        if not no_prompt:
+            typer.confirm("Do you want to preview data?", default=True, abort=True)
+
+    zipped_data = zip(sheet_names, sheet_metadata, headers, headers_idx, strict=True)
+
+    for idx, (sheet_name, metadata, header, header_idx) in enumerate(zipped_data):
+        print(f"Data for sheet - {sheet_name} - {metadata}")
+        rows = xlsx.read_to_dict_n_rows(
+            str(file_path), rows_to_read, header_idx, sheet_name
+        )
+        _print_format_data(header, rows)
+
+        if not no_prompt and idx < n_sheets - 1:
+            typer.confirm("Next sheet?", default=True, abort=True)
+
+
+def _preview_data(file_path: Path, rows_to_read: int = 5, sheet: str = None) -> None:
+    try:
+        headers, headers_idx = general.get_headers(file_path, sheet_name=sheet)
+        rows = general.data_file_to_dict_n_rows(
+            file_path, rows_to_read, headers_idx, sheet_name=sheet
+        )
+    except ValueError as e:
+        print("Something went wrong, the file is probably empty.\n" + str(e))
+        raise typer.Exit(code=1) from e
+    except (EmptyFileError, UnsupportedFileTypeError) as e:
+        print(e)
+        raise typer.Exit(code=1) from e
+
+    _print_format_data(headers, rows)
+
+
+def _print_format_data(headers: List[str], rows: List[DictRow]) -> None:
+    """Print the data in a formatted table."""
+    table = Table(*headers)
+    for row in rows:
+        table.add_row(*(str(r) for r in row.values()))
+    console.print(table)

--- a/src/geneweaver/client/cli/alpha/parse/utils.py
+++ b/src/geneweaver/client/cli/alpha/parse/utils.py
@@ -72,24 +72,22 @@ def get_metadata(file_path: Path, sheet: Optional[str] = None) -> None:
 @cli.command()
 @print_value_errors
 def preview(
-    file_path: Path, rows_to_read: int = 5, sheet: str = None, no_prompt: bool = False
+    file_path: Path, rows_to_read: int = 5, sheet: str = None, prompt: bool = True
 ) -> None:
     """Preview the data in a data file."""
     file_type = get_file_type(file_path)
     if file_type == "csv":
-        _preview_csv(file_path, rows_to_read, no_prompt)
+        _preview_csv(file_path, rows_to_read, prompt)
     elif file_type == "xlsx":
-        _preview_xlsx(file_path, rows_to_read, sheet, no_prompt)
+        _preview_xlsx(file_path, rows_to_read, sheet, prompt)
 
 
-def _preview_csv(
-    file_path: Path, rows_to_read: int = 5, no_prompt: bool = False
-) -> None:
+def _preview_csv(file_path: Path, rows_to_read: int = 5, prompt: bool = True) -> None:
     """Preview the data in a CSV file."""
     header, header_idx = csv.get_headers(file_path)
     _print_metadata_csv(file_path, header_idx)
 
-    if not no_prompt:
+    if prompt:
         typer.confirm("Do you want to preview data?", default=True, abort=True)
 
     rows = csv.read_to_dict_n_rows(file_path, rows_to_read, header_idx)
@@ -150,7 +148,7 @@ def _print_metadata_xlsx(
 
 
 def _preview_xlsx(
-    file_path: Path, rows_to_read: int = 5, sheet: str = None, no_prompt: bool = False
+    file_path: Path, rows_to_read: int = 5, sheet: str = None, prompt: bool = True
 ) -> None:
     sheet_names, sheet_metadata, headers, headers_idx, n_sheets = _get_metadata_xlsx(
         file_path, sheet
@@ -159,7 +157,7 @@ def _preview_xlsx(
     if not sheet:
         _print_metadata_xlsx(file_path, sheet_names, sheet_metadata, n_sheets)
 
-        if not no_prompt:
+        if prompt:
             typer.confirm("Do you want to preview data?", default=True, abort=True)
 
     zipped_data = zip(sheet_names, sheet_metadata, headers, headers_idx)  # noqa: B905
@@ -171,7 +169,7 @@ def _preview_xlsx(
         )
         _print_format_data(header, rows)
 
-        if not no_prompt and idx < n_sheets - 1:
+        if prompt and idx < n_sheets - 1:
             typer.confirm("Next sheet?", default=True, abort=True)
 
 

--- a/src/geneweaver/client/cli/alpha/parse/utils.py
+++ b/src/geneweaver/client/cli/alpha/parse/utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 import typer
+from geneweaver.client.cli.utils import print_value_errors
 from geneweaver.client.parser import general
 from geneweaver.core.parse import csv, xlsx
 from geneweaver.core.parse.exceptions import EmptyFileError, UnsupportedFileTypeError
@@ -17,6 +18,7 @@ console = Console()
 
 
 @cli.command()
+@print_value_errors
 def infer_file_format(file_path: Path) -> None:
     """Infer the file format of a data file."""
     file_type = get_file_type(file_path)
@@ -24,6 +26,7 @@ def infer_file_format(file_path: Path) -> None:
 
 
 @cli.command()
+@print_value_errors
 def get_headers(file_path: Path, sheet: str = None) -> None:
     """Get the headers from a data file."""
     try:
@@ -37,6 +40,7 @@ def get_headers(file_path: Path, sheet: str = None) -> None:
 
 
 @cli.command()
+@print_value_errors
 def get_sheet_names(file_path: Path) -> None:
     """Get the sheet names from an Excel file."""
     try:
@@ -50,6 +54,7 @@ def get_sheet_names(file_path: Path) -> None:
 
 
 @cli.command()
+@print_value_errors
 def get_metadata(file_path: Path, sheet: Optional[str] = None) -> None:
     """Get the metadata from a data file."""
     file_type = get_file_type(file_path)
@@ -65,12 +70,12 @@ def get_metadata(file_path: Path, sheet: Optional[str] = None) -> None:
 
 
 @cli.command()
+@print_value_errors
 def preview(
     file_path: Path, rows_to_read: int = 5, sheet: str = None, no_prompt: bool = False
 ) -> None:
     """Preview the data in a data file."""
     file_type = get_file_type(file_path)
-
     if file_type == "csv":
         _preview_csv(file_path, rows_to_read, no_prompt)
     elif file_type == "xlsx":

--- a/src/geneweaver/client/cli/alpha/parse/utils.py
+++ b/src/geneweaver/client/cli/alpha/parse/utils.py
@@ -130,7 +130,7 @@ def _get_metadata_xlsx(
 
         sheet_metadata = [
             general.read_metadata(file_path, h, sheet_name=s)
-            for s, h in zip(sheet_names, headers_idx, strict=True)
+            for s, h in zip(sheet_names, headers_idx)  # noqa: B905
         ]
         n_sheets = len(sheet_names)
 
@@ -145,7 +145,7 @@ def _print_metadata_xlsx(
 ) -> None:
     print(f"{file_path} contains {n_sheets} sheets:")
 
-    for name, metadata in zip(sheet_names, sheet_metadata, strict=True):
+    for name, metadata in zip(sheet_names, sheet_metadata):  # noqa: B905
         print(f" - {name} - {metadata}")
 
 
@@ -162,7 +162,7 @@ def _preview_xlsx(
         if not no_prompt:
             typer.confirm("Do you want to preview data?", default=True, abort=True)
 
-    zipped_data = zip(sheet_names, sheet_metadata, headers, headers_idx, strict=True)
+    zipped_data = zip(sheet_names, sheet_metadata, headers, headers_idx)  # noqa: B905
 
     for idx, (sheet_name, metadata, header, header_idx) in enumerate(zipped_data):
         print(f"Data for sheet - {sheet_name} - {metadata}")

--- a/src/geneweaver/client/cli/utils.py
+++ b/src/geneweaver/client/cli/utils.py
@@ -1,0 +1,19 @@
+"""Utility functions for use with the CLI."""
+import functools
+from typing import Callable
+
+import typer
+
+
+def print_value_errors(func: Callable) -> Callable:
+    """Print any value errors that occur in the decorated function."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        try:
+            return func(*args, **kwargs)
+        except ValueError as e:
+            print(f"An error occurred: {e}")
+            typer.Exit(code=1)
+
+    return wrapper

--- a/tests/unit/cli/test_parser.py
+++ b/tests/unit/cli/test_parser.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 from zipfile import BadZipFile
 
 from geneweaver.client.cli.alpha.parse import cli
-from geneweaver.core.parse.exceptions import EmptyFileError
 from openpyxl.utils.exceptions import InvalidFileException
 from typer.testing import CliRunner
 
@@ -44,78 +43,6 @@ def test_get_headers_with_value_error(mock_get_headers):
 
     # Check if the mocked function was called
     mock_get_headers.assert_called_once()
-
-
-@patch(
-    "geneweaver.client.parser.general.get_headers",
-    return_value=(["header1", "header2", "header3"], 0),
-)
-@patch(
-    "geneweaver.client.parser.general.data_file_to_dict_n_rows",
-    return_value=[{"header1": "val1", "header2": "val2", "header3": "val3"}],
-)
-def test_preview(mock_data_file_to_dict_n_rows, mock_get_headers):
-    """Test the preview CLI command."""
-    # Simulate the CLI execution
-    result = runner.invoke(cli, ["utils", "preview", "fake_path"])
-
-    print(result.output)
-
-    # # Check the output message
-    assert "header1" in result.output
-    assert "header2" in result.output
-    assert "header3" in result.output
-    assert "val1" in result.output
-    assert "val2" in result.output
-    assert "val3" in result.output
-
-    # # Check the exit code
-    assert result.exit_code == 0
-
-
-@patch(
-    "geneweaver.client.parser.general.get_headers",
-    return_value=(["header1", "header2", "header3"], 0),
-)
-@patch(
-    "geneweaver.client.parser.general.data_file_to_dict_n_rows",
-    return_value=[{"header1": "val1", "header2": "val2", "header3": "val3"}],
-    side_effect=EmptyFileError("File is empty."),
-)
-def test_preview_get_data_error(mock_data_file_to_dict_n_rows, mock_get_headers):
-    """Test the preview CLI command with an error."""
-    # Simulate the CLI execution
-    result = runner.invoke(cli, ["utils", "preview", "fake_path"])
-
-    # Check the output message
-    assert "File is empty." in result.output
-    # Check the exit code
-    assert result.exit_code == 1
-
-    # Check if the mocked function was called
-    mock_get_headers.assert_called_once()
-    mock_data_file_to_dict_n_rows.assert_called_once()
-
-
-@patch(
-    "geneweaver.client.parser.general.get_headers",
-    return_value=(["header1", "header2", "header3"], 0),
-    side_effect=ValueError("File is empty."),
-)
-@patch("geneweaver.client.parser.general.data_file_to_dict_n_rows", return_value=[])
-def test_preview_get_headers_error(mock_data_file_to_dict_n_rows, mock_get_headers):
-    """Test the preview CLI command with a get_headers error."""
-    # Simulate the CLI execution
-    result = runner.invoke(cli, ["utils", "preview", "fake_path"])
-
-    # Check the output message
-    assert "File is empty." in result.output
-    # Check the exit code
-    assert result.exit_code == 1
-
-    # Check if the mocked function was called
-    mock_get_headers.assert_called_once()
-    mock_data_file_to_dict_n_rows.assert_not_called()
 
 
 @patch(

--- a/tests/unit/parser/test_general.py
+++ b/tests/unit/parser/test_general.py
@@ -10,8 +10,8 @@ from geneweaver.core.parse.exceptions import UnsupportedFileTypeError
 @pytest.mark.parametrize(
     ("file_type", "expected_result"),
     [
-        ("csv", ["csv_header1", "csv_header2"]),
-        ("xlsx", ["xlsx_header1", "xlsx_header2"]),
+        ("csv", (["csv_header1", "csv_header2"], [])),
+        ("xlsx", (["xlsx_header1", "xlsx_header2"], [])),
     ],
 )
 @patch("geneweaver.client.parser.general.utils.get_file_type")


### PR DESCRIPTION
Finish implementations of the data file previewing commands.

- Adds the `gweave alpha parse utils infer-file-format` command.
- Adds the `gweave alpha parse utils get-metadata` command.
- Finishes implementation of the `gweave alpha parse utils preview` command.

The preview command now works on multi-sheet excel documents, prints formatted metadata for each sheet, and prompts for continued printing.

The `--no-prompt` flag allows for a clean print without user input.
