### PR TITLE
G3 29 - 0.6.0a2 - Prompt To Keep Bugfix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11']
     uses: ./.github/workflows/_run-tests-action.yml
     with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-client"
-version = "0.6.0a1"
+version = "0.6.0a2"
 description = "A Python Client for the Geneweaver API"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/client/utils/cli/prompt/generic.py
+++ b/src/geneweaver/client/utils/cli/prompt/generic.py
@@ -77,5 +77,5 @@ def prompt_if_none_or_ask_to_keep(
     if value is None:
         value = prompt_if_none(field_name, value)
     elif not prompt_to_keep_field(field_name, value, default=default):
-        value = prompt_if_none(field_name, value)
+        value = prompt_if_none(field_name, None)
     return value


### PR DESCRIPTION
This fixes a bug found by @desais-jax where the prompt to change the value header would not update.

I am also disabling the macOS runners at the request of @kurtshowmaker. As a note, I will make this same change across all the Geneweaver repositories on each of the next commits. 