### PR TITLE
Updating homolog endpoint, adding refresh token logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-client"
-version = "0.7.0a1"
+version = "0.7.0a2"
 description = "A Python Client for the Geneweaver API"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/client/api/genes.py
+++ b/src/geneweaver/client/api/genes.py
@@ -38,6 +38,6 @@ def map_homologs(
         post_args["source_species"] = int(source_species)
 
     with sessionmanager(token=access_token) as session:
-        resp = session.post(format_endpoint(ENDPOINT, "homologous-ids"), json=post_args)
+        resp = session.post(format_endpoint(ENDPOINT, "homologs"), json=post_args)
 
     return resp.json()

--- a/src/geneweaver/client/core/config_class.py
+++ b/src/geneweaver/client/core/config_class.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     AUTH_DOMAIN = "geneweaver.auth0.com"
     AUTH_CLIENT_ID = "tvcvnbBJQr15jFds8ZkwgHoqRJ0IuGJC"
     AUTH_ALGORITHMS = ["RS256"]
-    AUTH_SCOPES = ["openid", "profile", "email"]
+    AUTH_SCOPES = ["openid", "profile", "email", "offline_access"]
 
     API_HOST: str = "https://geneweaver-prod.jax.org"
     API_PATH: str = "/api"

--- a/tests/unit/auth/test_get_access_token.py
+++ b/tests/unit/auth/test_get_access_token.py
@@ -14,17 +14,56 @@ from geneweaver.client.auth import get_access_token
         None,
     ],
 )
-def test_get_access_token(token_data):
+@patch("geneweaver.client.auth._get_token_data_value_or_none")
+@patch("geneweaver.client.auth.access_token_expired")
+@patch("geneweaver.client.auth.refresh_token")
+def test_get_access_token(mock_refresh, mock_expired, mock_get_token, token_data):
     """Test the get_access_token function with mock data."""
-    with patch(
-        "geneweaver.client.auth._get_token_data_value_or_none"
-    ) as mock_get_token_data:
-        # Mock return value for _get_token_data_value_or_none
-        mock_get_token_data.return_value = token_data
+    mock_expired.return_value = False
+    mock_get_token.side_effect = [token_data, token_data]
+    mock_refresh.return_value = None
 
-        # Call get_access_token and assert its return value
-        result = get_access_token()
-        assert result == token_data
+    # Call get_access_token and assert its return value
+    result = get_access_token()
+    assert result == token_data
 
-        # Assert _get_token_data_value_or_none was called correctly
-        mock_get_token_data.assert_called_once_with("access_token")
+    # Assert _get_token_data_value_or_none was called correctly
+    assert mock_get_token.call_count == 1
+    # Assert access_token_expired was called correctly
+    assert mock_expired.call_count == 1
+    # Refresh token should not be called
+    assert mock_refresh.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "token_data",
+    [
+        {"access_token": "mock_access_token"},
+        {"access_token": "mock_access_token", "other_key": "other_value"},
+        {"other_key": "other_value"},
+        None,
+    ],
+)
+@patch("geneweaver.client.auth._get_token_data_value_or_none")
+@patch("geneweaver.client.auth.access_token_expired")
+@patch("geneweaver.client.auth.refresh_token")
+def test_get_access_token_expired(mock_refresh, mock_expired, mock_get_token, token_data):
+    """Test the get_access_token function with mock data."""
+    mock_expired.return_value = True
+    mock_get_token.side_effect = [token_data, token_data]
+    mock_refresh.return_value = None
+
+    # Mock return value for _get_token_data_value_or_none
+    mock_expired.return_value = True
+    mock_get_token.side_effect = [token_data, token_data]
+
+    # Call get_access_token and assert its return value
+    result = get_access_token()
+    assert result == token_data
+
+    # Assert _get_token_data_value_or_none was called correctly
+    assert mock_get_token.call_count == 2
+    # Assert access_token_expired was called correctly
+    assert mock_expired.call_count == 1
+    # Refresh token should be called
+    assert mock_refresh.call_count == 1

--- a/tests/unit/auth/test_get_access_token.py
+++ b/tests/unit/auth/test_get_access_token.py
@@ -47,7 +47,9 @@ def test_get_access_token(mock_refresh, mock_expired, mock_get_token, token_data
 @patch("geneweaver.client.auth._get_token_data_value_or_none")
 @patch("geneweaver.client.auth.access_token_expired")
 @patch("geneweaver.client.auth.refresh_token")
-def test_get_access_token_expired(mock_refresh, mock_expired, mock_get_token, token_data):
+def test_get_access_token_expired(
+    mock_refresh, mock_expired, mock_get_token, token_data
+):
     """Test the get_access_token function with mock data."""
     mock_expired.return_value = True
     mock_get_token.side_effect = [token_data, token_data]

--- a/tests/unit/auth/test_token_payload.py
+++ b/tests/unit/auth/test_token_payload.py
@@ -28,6 +28,7 @@ def test_token_payload(device_code):
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
             "device_code": device_code,
             "client_id": "mock_client_id",
+            "scope": "offline_access",
         }
 
         # Call the function and assert its return value


### PR DESCRIPTION
This change is to help address usability concerns with the geneset client documentation.

It updates the homolog endpoint to match the most recent release.

It also adds logic to refresh the access token to make the auth process simpler.