### PR TITLE
Fixing Ensemble Compara option to be consistent with other options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-client"
-version = "0.9.0a1"
+version = "0.9.0a2"
 description = "A Python Client for the Geneweaver API"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/client/api/aon.py
+++ b/src/geneweaver/client/api/aon.py
@@ -19,7 +19,7 @@ class OrthologAlgorithms(Enum):
     INPARANOID = "InParanoid"
     ORTHOFINDER = "OrthoFinder"
     ZFIN = "ZFIN"
-    ENSEMBL_COMPARA = "Ensembl Compara"
+    ENSEMBLCOMPARA = "EnsemblCompara"
     SONICPARANOID = "SonicParanoid"
     OMA = "OMA"
     XENBASE = "Xenbase"


### PR DESCRIPTION
This PR changes the name of option `--algorithm 'Ensembl Compara'`  to `--algorithm EnsemblCompara`, removing the need for quotes, and making command usage consistent across Windows and MacOS.